### PR TITLE
Reverse button order on payment requests

### DIFF
--- a/app/src/main/res/layout/list_item__request_remote.xml
+++ b/app/src/main/res/layout/list_item__request_remote.xml
@@ -97,24 +97,24 @@
             app:layout_gravity="right">
 
             <Button
-                android:id="@+id/approve_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                style="@style/TextViewButton"
-                android:textSize="13sp"
-                android:text="@string/button_accept"/>
-
-            <android.support.v4.widget.Space
-                android:layout_width="20dp"
-                android:layout_height="0dp" />
-
-            <Button
                 android:id="@+id/reject_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 style="@style/TextViewButton"
                 android:textSize="13sp"
                 android:text="@string/button_decline"/>
+
+            <android.support.v4.widget.Space
+                android:layout_width="20dp"
+                android:layout_height="0dp" />
+
+            <Button
+                android:id="@+id/approve_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/TextViewButton"
+                android:textSize="13sp"
+                android:text="@string/button_accept"/>
 
         </LinearLayout>
 


### PR DESCRIPTION
Put positive action on right because the positive action is on the right in android dialogs.

![screen shot 2017-11-06 at 11 25 29](https://user-images.githubusercontent.com/4302925/32436849-a9d849e8-c2e5-11e7-832e-44ed58922ad2.png)
