### PR TITLE
Show `[Corrupt message]` instead of last message when message is corrupt

### DIFF
--- a/app/src/main/java/com/toshi/view/adapter/MessageAdapter.java
+++ b/app/src/main/java/com/toshi/view/adapter/MessageAdapter.java
@@ -125,12 +125,19 @@ public final class MessageAdapter extends RecyclerView.Adapter<RecyclerView.View
         notifyDataSetChanged();
 
         for (SofaMessage sofaMessage : sofaMessages) {
-            addMessage(sofaMessage);
+            try {
+                addMessage(sofaMessage);
+            } catch (IOException ex) {
+                LogUtil.error(getClass(), "Unable to render view holder: " + ex);
+            }
         }
     }
 
-    private void addMessage(final SofaMessage sofaMessage) {
+    private void addMessage(final SofaMessage sofaMessage) throws IOException {
         if (sofaMessage == null || !sofaMessage.isUserVisible()) return;
+        String payload = sofaMessage.getPayload();
+        if (payload == null) return;
+        SofaAdapters.get().messageFrom(payload);
         this.sofaMessages.add(sofaMessage);
         notifyItemInserted(this.sofaMessages.size() - 1);
         if (this.sofaMessages.size() > 1) {
@@ -143,7 +150,11 @@ public final class MessageAdapter extends RecyclerView.Adapter<RecyclerView.View
         if (sofaMessage == null || !sofaMessage.isUserVisible()) return;
         final int position = this.sofaMessages.indexOf(sofaMessage);
         if (position == -1) {
-            addMessage(sofaMessage);
+            try {
+                addMessage(sofaMessage);
+            } catch (IOException ex) {
+                LogUtil.error(getClass(), "Unable to render view holder: " + ex);
+            }
             return;
         }
 


### PR DESCRIPTION
In the chat the JsonDataException currently causes old messages to be
repeated when bots send controls that are structured incorrectly. This
happens because the message-views are recycled and not reset when the
exception gets thrown.

Adding this replacement message will hopefully make it easier for
bot-developers to figure out what is wrong.