### PR TITLE
Edit group

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,7 +75,7 @@
         <activity android:name="com.toshi.view.activity.GroupInfoActivity" />
         <activity android:name="com.toshi.view.activity.ViewProfileActivity" />
         <activity android:name="com.toshi.view.activity.EditProfileActivity" />
-        <activity android:name="com.toshi.view.activity.NewConversationActivity" />
+        <activity android:name="com.toshi.view.activity.ConversationSetupActivity" />
         <activity android:name="com.toshi.view.activity.AmountActivity" />
         <activity android:name="com.toshi.view.activity.ScannerActivity"
                   android:theme="@style/FullScreenTheme"/>

--- a/app/src/main/java/com/toshi/manager/SofaMessageManager.java
+++ b/app/src/main/java/com/toshi/manager/SofaMessageManager.java
@@ -18,8 +18,6 @@
 package com.toshi.manager;
 
 
-import android.util.Pair;
-
 import com.toshi.BuildConfig;
 import com.toshi.R;
 import com.toshi.crypto.HDWallet;
@@ -52,6 +50,7 @@ import org.whispersystems.signalservice.internal.configuration.SignalServiceUrl;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
+import kotlin.Triple;
 import rx.Completable;
 import rx.Observable;
 import rx.Single;
@@ -210,8 +209,9 @@ public final class SofaMessageManager {
     }
 
     // Returns a pair of RxSubjects, the first being the observable for new messages
-    // the second being the observable for updated messages.
-    public final Pair<PublishSubject<SofaMessage>, PublishSubject<SofaMessage>> registerForConversationChanges(final String threadId) {
+    // the second being the observable for updated messages
+    // the third being the observable for any changes to the conversation (i.e. if the name or avatar is changed)
+    public final Triple<PublishSubject<SofaMessage>, PublishSubject<SofaMessage>, PublishSubject<Conversation>> registerForConversationChanges(final String threadId) {
         return this.conversationStore.registerForChanges(threadId);
     }
 

--- a/app/src/main/java/com/toshi/manager/SofaMessageManager.java
+++ b/app/src/main/java/com/toshi/manager/SofaMessageManager.java
@@ -116,6 +116,14 @@ public final class SofaMessageManager {
                 .flatMap(this.conversationStore::createNewConversationFromGroup);
     }
 
+    public final Completable updateConversationFromGroup(final Group group) {
+        return Completable.fromAction(() -> {
+            messageSender.sendGroupInfo(group.getMembers(), group);
+            this.conversationStore.saveGroup(group);
+        })
+                .subscribeOn(Schedulers.io());
+    }
+
     @NotNull
     public Completable leaveGroup(@NotNull final Group group) {
         return Completable

--- a/app/src/main/java/com/toshi/manager/chat/SofaMessageSender.java
+++ b/app/src/main/java/com/toshi/manager/chat/SofaMessageSender.java
@@ -48,6 +48,8 @@ import org.whispersystems.signalservice.internal.configuration.SignalCdnUrl;
 import org.whispersystems.signalservice.internal.configuration.SignalServiceConfiguration;
 import org.whispersystems.signalservice.internal.configuration.SignalServiceUrl;
 
+import java.util.List;
+
 import rx.Single;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
@@ -169,6 +171,10 @@ public class SofaMessageSender {
 
     public void sendGroupInfo(@NotNull final String messageSource, @NotNull final Group group) {
         new SendGroupInfoTask(this.signalMessageSender).run(messageSource, group);
+    }
+
+    public void sendGroupInfo(@NotNull final List<User> users, @NotNull final Group group) {
+        new SendGroupInfoTask(this.signalMessageSender).run(users, group);
     }
 
     public void leaveGroup(final Group group) {

--- a/app/src/main/java/com/toshi/manager/chat/tasks/SendGroupInfoTask.kt
+++ b/app/src/main/java/com/toshi/manager/chat/tasks/SendGroupInfoTask.kt
@@ -19,6 +19,7 @@ package com.toshi.manager.chat.tasks
 
 import com.toshi.exception.GroupCreationException
 import com.toshi.model.local.Group
+import com.toshi.model.local.User
 import org.whispersystems.libsignal.util.Hex
 import org.whispersystems.signalservice.api.SignalServiceMessageSender
 import org.whispersystems.signalservice.api.messages.SignalServiceDataMessage
@@ -30,6 +31,13 @@ import java.io.IOException
 class SendGroupInfoTask(
         private val signalMessageSender: SignalServiceMessageSender
 ) {
+    fun run(requestingUsers: List<User>, group: Group) {
+        for (requestingUser in requestingUsers) {
+            val requestingUserAddress = requestingUser.toshiId
+            run(requestingUserAddress, group)
+        }
+    }
+
     fun run(requestingUserAddress: String, group: Group) {
         if (!shouldSendGroupInfo(requestingUserAddress, group)) return
         try {

--- a/app/src/main/java/com/toshi/presenter/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/toshi/presenter/chat/ChatViewModel.kt
@@ -61,6 +61,7 @@ class ChatViewModel(private val threadId: String) : ViewModel() {
     val acceptConversation by lazy { SingleLiveEvent<Unit>() }
     val declineConversation by lazy { SingleLiveEvent<Unit>() }
     val updateMessage by lazy { SingleLiveEvent<SofaMessage>() }
+    val updateConversation by lazy { SingleLiveEvent<Conversation>() }
     val newMessage by lazy { SingleLiveEvent<SofaMessage>() }
     val deleteMessage by lazy { SingleLiveEvent<SofaMessage>() }
     val error by lazy { SingleLiveEvent<Int>() }
@@ -163,6 +164,16 @@ class ChatViewModel(private val threadId: String) : ViewModel() {
                         { LogUtil.exception(javaClass, it) }
                 )
 
+        val updateConversationSub = sofaMessageManager
+                .registerForConversationChanges(recipient.threadId)
+                .third
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        { updateConversation.value = it },
+                        { LogUtil.exception(javaClass, it) }
+                )
+
         val deleteSub = sofaMessageManager
                 .registerForDeletedMessages(recipient.threadId)
                 .subscribeOn(Schedulers.io())
@@ -175,6 +186,7 @@ class ChatViewModel(private val threadId: String) : ViewModel() {
         subscriptions.addAll(
                 chatSub,
                 updateSub,
+                updateConversationSub,
                 deleteSub
         )
     }

--- a/app/src/main/java/com/toshi/view/activity/ChatActivity.kt
+++ b/app/src/main/java/com/toshi/view/activity/ChatActivity.kt
@@ -319,6 +319,9 @@ class ChatActivity : AppCompatActivity() {
         viewModel.updateMessage.observe(this, Observer {
             updatedMessage -> updatedMessage?.let { messageAdapter.updateMessage(it) }
         })
+        viewModel.updateConversation.observe(this, Observer {
+            updatedMessage -> updatedMessage?.let { initToolbar(it.recipient) }
+        })
         viewModel.deleteMessage.observe(this, Observer {
             deletedMessage -> deletedMessage?.let { messageAdapter.deleteMessage(it) }
         })

--- a/app/src/main/java/com/toshi/view/activity/ConversationSetupActivity.kt
+++ b/app/src/main/java/com/toshi/view/activity/ConversationSetupActivity.kt
@@ -43,7 +43,7 @@ import com.toshi.view.fragment.newconversation.UserParticipantsFragment
 import com.toshi.viewModel.NewConversationViewModel
 import java.io.File
 
-class NewConversationActivity : AppCompatActivity() {
+class ConversationSetupActivity : AppCompatActivity() {
 
     companion object {
         private val PICK_IMAGE = 1

--- a/app/src/main/java/com/toshi/view/activity/ConversationSetupActivity.kt
+++ b/app/src/main/java/com/toshi/view/activity/ConversationSetupActivity.kt
@@ -49,6 +49,7 @@ class ConversationSetupActivity : AppCompatActivity() {
         private val PICK_IMAGE = 1
         private val CAPTURE_IMAGE = 2
         private val INTENT_TYPE = "image/*"
+        val EXTRA__GROUP_ID_FOR_EDITING = "extra_group_id_for_editing"
     }
 
     private val chooserDialog by lazy { ChooserDialog.newInstance() }
@@ -58,7 +59,7 @@ class ConversationSetupActivity : AppCompatActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         init()
-        if (savedInstanceState == null) openFragment(UserParticipantsFragment())
+        openCorrectFragment(savedInstanceState)
     }
 
     private fun init() {
@@ -71,6 +72,17 @@ class ConversationSetupActivity : AppCompatActivity() {
     }
 
     private fun initView() = setContentView(R.layout.activity_new_conversation)
+
+    private fun openCorrectFragment(savedInstanceState: Bundle?) {
+        val groupIdForEditing = intent?.getStringExtra(EXTRA__GROUP_ID_FOR_EDITING)
+        groupIdForEditing?.let {
+            intent.removeExtra(EXTRA__GROUP_ID_FOR_EDITING)
+            openFragment(GroupSetupFragment().setGroupId(groupIdForEditing))
+            return
+        }
+
+        if (savedInstanceState == null) openFragment(UserParticipantsFragment())
+    }
 
     private fun openFragment(fragment: Fragment) {
         supportFragmentManager

--- a/app/src/main/java/com/toshi/view/activity/GroupInfoActivity.kt
+++ b/app/src/main/java/com/toshi/view/activity/GroupInfoActivity.kt
@@ -139,7 +139,7 @@ class GroupInfoActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.edit -> LogUtil.d(javaClass, "Not implemented")
+            R.id.edit -> startGroupEditActivity(viewModel.group.value)
             R.id.leave -> handleLeaveGroup()
         }
         return super.onOptionsItemSelected(item)
@@ -155,6 +155,10 @@ class GroupInfoActivity : AppCompatActivity() {
 
     private fun startChatActivity(user: User) = startActivityAndFinish<ChatActivity> {
         putExtra(ChatActivity.EXTRA__THREAD_ID, user.toshiId)
+    }
+
+    private fun startGroupEditActivity(group: Group?) = startActivityAndFinish<ConversationSetupActivity> {
+        putExtra(ConversationSetupActivity.EXTRA__GROUP_ID_FOR_EDITING, group?.id)
     }
 
     private fun returnToMainActivity() = startActivity<MainActivity> {

--- a/app/src/main/java/com/toshi/view/fragment/newconversation/GroupParticipantsFragment.kt
+++ b/app/src/main/java/com/toshi/view/fragment/newconversation/GroupParticipantsFragment.kt
@@ -32,7 +32,7 @@ import com.toshi.R
 import com.toshi.extensions.addHorizontalLineDivider
 import com.toshi.extensions.isVisible
 import com.toshi.model.local.User
-import com.toshi.view.activity.NewConversationActivity
+import com.toshi.view.activity.ConversationSetupActivity
 import com.toshi.view.adapter.UserAdapter
 import com.toshi.viewModel.GroupParticipantsViewModel
 import kotlinx.android.synthetic.main.fragment_group_participants.*
@@ -65,7 +65,7 @@ class GroupParticipantsFragment : Fragment() {
         next.setOnClickListener { handleNextClicked() }
     }
 
-    private fun handleNextClicked() = (this.activity as NewConversationActivity).openGroupSetupFlow(viewModel.selectedParticipants.value!!)
+    private fun handleNextClicked() = (this.activity as ConversationSetupActivity).openGroupSetupFlow(viewModel.selectedParticipants.value!!)
 
     private fun initRecyclerView() {
         userAdapter = UserAdapter().setOnItemClickListener(this::handleUserClicked)

--- a/app/src/main/java/com/toshi/view/fragment/newconversation/GroupSetupFragment.kt
+++ b/app/src/main/java/com/toshi/view/fragment/newconversation/GroupSetupFragment.kt
@@ -125,6 +125,9 @@ class GroupSetupFragment : Fragment() {
             viewModel.group.observe(this, Observer {
                 updateUiFromGroup(it)
             })
+            viewModel.groupUpdated.observe(this, Observer {
+                (this.activity as ConversationSetupActivity).finish()
+            })
         }
     }
 
@@ -135,6 +138,7 @@ class GroupSetupFragment : Fragment() {
             groupName.setText(group.title)
             initNumberOfParticipantsView()
             create.setText(R.string.update_group)
+            create.setOnClickListener { viewModel.updateGroup(group, avatarUri, groupName.text.toString()) }
         }
     }
 

--- a/app/src/main/java/com/toshi/view/fragment/newconversation/GroupSetupFragment.kt
+++ b/app/src/main/java/com/toshi/view/fragment/newconversation/GroupSetupFragment.kt
@@ -36,7 +36,7 @@ import com.toshi.extensions.toast
 import com.toshi.model.local.User
 import com.toshi.util.ImageUtil
 import com.toshi.util.LogUtil
-import com.toshi.view.activity.NewConversationActivity
+import com.toshi.view.activity.ConversationSetupActivity
 import com.toshi.view.adapter.GroupParticipantAdapter
 import com.toshi.viewModel.GroupSetupViewModel
 import kotlinx.android.synthetic.main.fragment_group_setup.*
@@ -81,7 +81,7 @@ class GroupSetupFragment : Fragment() {
     private fun initClickListeners() {
         create.setOnClickListener { viewModel.createGroup(selectedParticipants, avatarUri, groupName.text.toString()) }
         closeButton.setOnClickListener { this.activity.onBackPressed() }
-        avatar.setOnClickListener { (this.activity as NewConversationActivity).showImageChooserDialog() }
+        avatar.setOnClickListener { (this.activity as ConversationSetupActivity).showImageChooserDialog() }
     }
 
     private fun initRecyclerView() {
@@ -107,7 +107,7 @@ class GroupSetupFragment : Fragment() {
     private fun initObservers() {
         initNameListener()
         viewModel.conversationCreated.observe(this, Observer {
-            (this.activity as NewConversationActivity).openConversation(it)
+            (this.activity as ConversationSetupActivity).openConversation(it)
         })
         viewModel.error.observe(this, Observer {
             LogUtil.exception(this::class.java, it)

--- a/app/src/main/java/com/toshi/view/fragment/newconversation/UserParticipantsFragment.kt
+++ b/app/src/main/java/com/toshi/view/fragment/newconversation/UserParticipantsFragment.kt
@@ -34,7 +34,7 @@ import com.toshi.extensions.addHorizontalLineDivider
 import com.toshi.extensions.isVisible
 import com.toshi.model.local.User
 import com.toshi.util.KeyboardUtil
-import com.toshi.view.activity.NewConversationActivity
+import com.toshi.view.activity.ConversationSetupActivity
 import com.toshi.view.adapter.UserAdapter
 import com.toshi.viewModel.UserParticipantsViewModel
 import kotlinx.android.synthetic.main.fragment_user_participants.*
@@ -77,7 +77,7 @@ class UserParticipantsFragment : Fragment() {
         this.activity.onBackPressed()
     }
 
-    private fun handleNewGroupClicked() = (this.activity as NewConversationActivity).openNewGroupFlow()
+    private fun handleNewGroupClicked() = (this.activity as ConversationSetupActivity).openNewGroupFlow()
 
     private fun initRecyclerView() {
         userAdapter = UserAdapter().setOnItemClickListener(this::handleUserClicked)
@@ -89,7 +89,7 @@ class UserParticipantsFragment : Fragment() {
         }
     }
 
-    private fun handleUserClicked(user: User) = (this.activity as NewConversationActivity).openConversation(user)
+    private fun handleUserClicked(user: User) = (this.activity as ConversationSetupActivity).openConversation(user)
 
     private fun initObservers() {
         initSearch()

--- a/app/src/main/java/com/toshi/view/fragment/toplevel/RecentFragment.kt
+++ b/app/src/main/java/com/toshi/view/fragment/toplevel/RecentFragment.kt
@@ -35,7 +35,7 @@ import com.toshi.model.local.Conversation
 import com.toshi.model.local.ConversationInfo
 import com.toshi.view.activity.ChatActivity
 import com.toshi.view.activity.ConversationRequestActivity
-import com.toshi.view.activity.NewConversationActivity
+import com.toshi.view.activity.ConversationSetupActivity
 import com.toshi.view.adapter.RecentAdapter
 import com.toshi.view.adapter.listeners.OnItemClickListener
 import com.toshi.view.adapter.listeners.OnUpdateListener
@@ -78,8 +78,8 @@ class RecentFragment : Fragment(), TopLevelFragment {
     }
 
     private fun initClickListeners() {
-        startChat.setOnClickListener { startActivity<NewConversationActivity>() }
-        add.setOnClickListener { startActivity<NewConversationActivity>() }
+        startChat.setOnClickListener { startActivity<ConversationSetupActivity>() }
+        add.setOnClickListener { startActivity<ConversationSetupActivity>() }
     }
 
     private fun restoreScrollPosition(inState: Bundle?) {

--- a/app/src/main/java/com/toshi/viewModel/GroupSetupViewModel.kt
+++ b/app/src/main/java/com/toshi/viewModel/GroupSetupViewModel.kt
@@ -27,6 +27,7 @@ import com.toshi.model.local.User
 import com.toshi.util.ImageUtil
 import com.toshi.util.SingleLiveEvent
 import com.toshi.view.BaseApplication
+import rx.Completable
 import rx.Single
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
@@ -38,6 +39,7 @@ class GroupSetupViewModel : ViewModel() {
     private var isCreatingGroup = false
 
     val conversationCreated by lazy { SingleLiveEvent<Conversation>() }
+    val groupUpdated by lazy { SingleLiveEvent<Group>() }
     val group by lazy { SingleLiveEvent<Group>() }
     val error by lazy { SingleLiveEvent<Throwable>() }
 
@@ -73,12 +75,37 @@ class GroupSetupViewModel : ViewModel() {
         subscriptions.add(subscription)
     }
 
+    fun updateGroup(group: Group,
+                    avatarUri: Uri?,
+                    groupName: String) {
+        if (isCreatingGroup) return
+        isCreatingGroup = true
+        val subscription = generateAvatarFromUri(avatarUri)
+                .map { avatar -> updateGroupObject(group, avatar, groupName) }
+                .flatMapCompletable { saveUpdatedGroup(it) }
+                .observeOn(AndroidSchedulers.mainThread())
+                .doAfterTerminate { isCreatingGroup = false }
+                .subscribe(
+                        { groupUpdated.value = group },
+                        { error.value = it }
+                )
+        this.subscriptions.add(subscription)
+    }
+
     private fun createGroupObject(participants: List<User>,
                                   avatar: Bitmap?,
                                   groupName: String): Group {
         return Group(participants)
                 .setTitle(groupName)
                 .setAvatar(avatar)
+    }
+
+    private fun updateGroupObject(group: Group,
+                                  newAvatar: Bitmap?,
+                                  groupName: String): Group {
+        newAvatar?.let { group.setAvatar(newAvatar) }
+        group.title = groupName
+        return group
     }
 
     private fun addCurrentUserToGroup(group: Group): Single<Group> {
@@ -96,15 +123,14 @@ class GroupSetupViewModel : ViewModel() {
                 .createConversationFromGroup(group)
     }
 
-    private fun generateAvatarFromUri(avatarUri: Uri?): Single<Bitmap> {
-        return ImageUtil.loadAsBitmap(avatarUri, BaseApplication.get())
+    private fun saveUpdatedGroup(group: Group): Completable {
+        return BaseApplication
+                .get()
+                .sofaMessageManager
+                .updateConversationFromGroup(group)
     }
 
-    private fun tryGeneratePlaceholderAvatar(avatar: Bitmap?, groupName: String): Bitmap {
-        return avatar.let { avatar } ?: groupName.toIdenticon()
-    }
-
-    override fun onCleared() {
-        this.subscriptions.clear()
-    }
+    private fun generateAvatarFromUri(avatarUri: Uri?) = ImageUtil.loadAsBitmap(avatarUri, BaseApplication.get())
+    private fun tryGeneratePlaceholderAvatar(avatar: Bitmap?, groupName: String) = avatar.let { avatar } ?: groupName.toIdenticon()
+    override fun onCleared() = subscriptions.clear()
 }

--- a/app/src/main/java/com/toshi/viewModel/GroupSetupViewModel.kt
+++ b/app/src/main/java/com/toshi/viewModel/GroupSetupViewModel.kt
@@ -29,6 +29,7 @@ import com.toshi.util.SingleLiveEvent
 import com.toshi.view.BaseApplication
 import rx.Single
 import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
 import rx.subscriptions.CompositeSubscription
 
 class GroupSetupViewModel : ViewModel() {
@@ -37,6 +38,7 @@ class GroupSetupViewModel : ViewModel() {
     private var isCreatingGroup = false
 
     val conversationCreated by lazy { SingleLiveEvent<Conversation>() }
+    val group by lazy { SingleLiveEvent<Group>() }
     val error by lazy { SingleLiveEvent<Throwable>() }
 
     fun createGroup(participants: List<User>,
@@ -56,6 +58,19 @@ class GroupSetupViewModel : ViewModel() {
                         { error.value = it }
                 )
         this.subscriptions.add(subscription)
+    }
+
+    fun fetchGroup(groupId: String?) {
+        val subscription = BaseApplication.get()
+                .recipientManager
+                .getGroupFromId(groupId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        { group.value = it },
+                        { error.value = it }
+                )
+        subscriptions.add(subscription)
     }
 
     private fun createGroupObject(participants: List<User>,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,4 +296,5 @@
     <string name="leave">Leave</string>
     <string name="error_leave_group">Unable to leave group</string>
     <string name="local_currency_to_eth_error">Couldn\'t do currency conversion. Check your network connection.</string>
+    <string name="update_group">Update</string>
 </resources>


### PR DESCRIPTION
Add the ability to change name and image of group, by reusing GroupSetupFragment. Changes are broadcast over Signal and Realm is also updated.

The approach I have for updating the UI (using a PublishSubject) is a bit hacky. Might be time to fix that, perhaps in a different PR.