### PR TITLE
Fix/user agent

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,10 @@ android {
     }
 
     def webDebugEnabled = 'WEB_DEBUG_ENABLED'
+    def userAgent = { String applicationIdSuffix -> "Android " +
+            getDefaultConfig().applicationId + applicationIdSuffix + " - " +
+            getDefaultConfig().versionName + ":" +
+            getDefaultConfig().versionCode }
 
     buildTypes {
         debug {
@@ -55,6 +59,7 @@ android {
             debuggable true
             minifyEnabled false
             buildConfigField "boolean", webDebugEnabled, "true"
+            buildConfigField "String", "USER_AGENT", "\"${userAgent(".debug")}\""
         }
         developer {
             applicationIdSuffix ".developer"
@@ -64,6 +69,7 @@ android {
             debuggable false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             buildConfigField "boolean", webDebugEnabled, "true"
+            buildConfigField "String", "USER_AGENT", "\"${userAgent(".developer")}\""
         }
         release {
             multiDexEnabled true
@@ -72,6 +78,7 @@ android {
             debuggable false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             buildConfigField "boolean", webDebugEnabled, "false"
+            buildConfigField "String", "USER_AGENT", "\"${userAgent("")}\""
         }
     }
 

--- a/app/src/main/java/com/toshi/manager/chat/SofaMessageReceiver.java
+++ b/app/src/main/java/com/toshi/manager/chat/SofaMessageReceiver.java
@@ -56,8 +56,6 @@ import java.util.concurrent.TimeoutException;
 
 public class SofaMessageReceiver {
 
-    private final static String USER_AGENT = "Android " + BuildConfig.APPLICATION_ID + " - " + BuildConfig.VERSION_NAME +  ":" + BuildConfig.VERSION_CODE;
-
     private final ProtocolStore protocolStore;
     private final SignalServiceMessageReceiver messageReceiver;
     private final HDWallet wallet;
@@ -80,7 +78,7 @@ public class SofaMessageReceiver {
                         this.wallet.getOwnerAddress(),
                         this.protocolStore.getPassword(),
                         this.protocolStore.getSignalingKey(),
-                        USER_AGENT);
+                        BuildConfig.USER_AGENT);
 
         this.taskGroupUpdate = new GroupUpdateTask(this.messageReceiver, messageSender, conversationStore);
         this.taskHandleMessage = new HandleMessageTask(this.messageReceiver, conversationStore, this.wallet, messageSender);

--- a/app/src/main/java/com/toshi/manager/chat/SofaMessageSender.java
+++ b/app/src/main/java/com/toshi/manager/chat/SofaMessageSender.java
@@ -58,8 +58,6 @@ import rx.subscriptions.CompositeSubscription;
 
 public class SofaMessageSender {
 
-    private final static String USER_AGENT = "Android " + BuildConfig.APPLICATION_ID + " - " + BuildConfig.VERSION_NAME +  ":" + BuildConfig.VERSION_CODE;
-
     private final CompositeSubscription subscriptions;
     private final ConversationStore conversationStore;
     private final HDWallet wallet;
@@ -88,7 +86,7 @@ public class SofaMessageSender {
                         this.wallet.getOwnerAddress(),
                         this.protocolStore.getPassword(),
                         this.protocolStore,
-                        USER_AGENT,
+                        BuildConfig.USER_AGENT,
                         Optional.absent(),
                         Optional.absent()
                 );

--- a/app/src/main/java/com/toshi/manager/network/interceptor/DeviceInfoUserAgentInterceptor.kt
+++ b/app/src/main/java/com/toshi/manager/network/interceptor/DeviceInfoUserAgentInterceptor.kt
@@ -17,19 +17,18 @@
 
 package com.toshi.manager.network.interceptor
 
+import com.toshi.BuildConfig
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
 
 class DeviceInfoUserAgentInterceptor : Interceptor {
 
-    private val userAgent: String = System.getProperty("http.agent")
-
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response? {
         val original = chain.request()
         val request = original.newBuilder()
-                .header("User-Agent", this.userAgent)
+                .header("User-Agent", BuildConfig.USER_AGENT)
                 .method(original.method(), original.body())
                 .build()
         return chain.proceed(request)

--- a/app/src/main/java/com/toshi/presenter/webview/WebViewPresenter.java
+++ b/app/src/main/java/com/toshi/presenter/webview/WebViewPresenter.java
@@ -94,6 +94,7 @@ public class WebViewPresenter implements Presenter<WebViewActivity> {
         webSettings.setUseWideViewPort(true);
         webSettings.setLoadWithOverviewMode(true);
         webSettings.setDomStorageEnabled(true);
+        webSettings.setUserAgentString(BuildConfig.USER_AGENT);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             WebView.setWebContentsDebuggingEnabled(BuildConfig.WEB_DEBUG_ENABLED);


### PR DESCRIPTION
Construct the USER_AGENT string in one place only, at build time. Use it everywhere. Add it to both the SofaInjector client and the SofaWebView so that it is seen both by the requested server and by the client javascript context.

@csdodd no review needed, but peek for sanity

![screen shot 2017-12-13 at 15 36 38](https://user-images.githubusercontent.com/7949897/33944137-880b797c-e01b-11e7-823d-1a4f04742260.png)
