### PR TITLE
Mute status message alerts

### DIFF
--- a/app/src/main/java/com/toshi/extensions/SofaMessageExtensions.kt
+++ b/app/src/main/java/com/toshi/extensions/SofaMessageExtensions.kt
@@ -1,0 +1,24 @@
+/*
+ * 	Copyright (c) 2017. Toshi Inc
+ *
+ * 	This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+@file:JvmName("SofaMessageUtil")
+package com.toshi.extensions
+import com.toshi.model.sofa.SofaMessage
+import com.toshi.model.sofa.SofaType
+
+fun SofaMessage?.isLocalStatusMessage(): Boolean {
+    return this?.let { it.type == SofaType.LOCAL_STATUS_MESSAGE } ?: false
+}

--- a/app/src/main/java/com/toshi/manager/store/ConversationStore.java
+++ b/app/src/main/java/com/toshi/manager/store/ConversationStore.java
@@ -21,6 +21,7 @@ package com.toshi.manager.store;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.toshi.extensions.SofaMessageUtil;
 import com.toshi.model.local.Conversation;
 import com.toshi.model.local.ConversationObservables;
 import com.toshi.model.local.Group;
@@ -168,11 +169,10 @@ public class ConversationStore {
 
             if (message != null) {
                 final SofaMessage storedMessage = realm.copyToRealmOrUpdate(message);
-                if(conversationToStore.getThreadId().equals(watchedThreadId)) {
-                    conversationToStore.setLatestMessage(storedMessage);
-                } else {
-                    conversationToStore.setLatestMessageAndUpdateUnreadCounter(storedMessage);
-                }
+                final boolean updateUnreadCounter = !conversationToStore.getThreadId().equals(watchedThreadId)
+                        && !SofaMessageUtil.isLocalStatusMessage(storedMessage);
+                if (updateUnreadCounter) conversationToStore.setLatestMessageAndUpdateUnreadCounter(storedMessage);
+                else conversationToStore.setLatestMessage(storedMessage);
                 broadcastNewChatMessage(receiver.getThreadId(), message);
             }
 

--- a/app/src/main/java/com/toshi/viewModel/MainViewModel.kt
+++ b/app/src/main/java/com/toshi/viewModel/MainViewModel.kt
@@ -2,6 +2,7 @@ package com.toshi.viewModel
 
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
+import com.toshi.extensions.isLocalStatusMessage
 import com.toshi.util.LogUtil
 import com.toshi.view.BaseApplication
 import rx.android.schedulers.AndroidSchedulers
@@ -17,7 +18,9 @@ class MainViewModel : ViewModel() {
     }
 
     private fun attachUnreadMessagesSubscription() {
-        val allChangesSubscription = getSofaMessageManager().registerForAllConversationChanges()
+        val allChangesSubscription = getSofaMessageManager()
+                .registerForAllConversationChanges()
+                .filter { !it.latestMessage.isLocalStatusMessage() }
                 .flatMap { getSofaMessageManager().areUnreadMessages().toObservable() }
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
@@ -40,6 +43,7 @@ class MainViewModel : ViewModel() {
     private fun getSofaMessageManager() = BaseApplication.get().sofaMessageManager
 
     override fun onCleared() {
+        super.onCleared()
         subscriptions.clear()
     }
 }


### PR DESCRIPTION
We don't want to disturb the user with status messages. 

In this PR I filter out all status messages in `MainViewModel`. This prevents the red dot on the nav bar to update. I also don't update the unread counter if `SofaMessage` is of status message type in `ConversationStore`