### PR TITLE
Chat refactor, pt 3: Convert to ConstraintLayout, fix design nits

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,6 +127,7 @@ dependencies {
             "com.android.support:gridlayout-v7:${supportLibVersion}",
             "com.android.support:design:${supportLibVersion}",
             "com.android.support:cardview-v7:${supportLibVersion}",
+            'com.android.support.constraint:constraint-layout:1.0.2',
             'com.android.support:multidex:1.0.0',
             'com.google.android:flexbox:0.2.6',
             // Push notifications

--- a/app/src/main/res/drawable/circle_border.xml
+++ b/app/src/main/res/drawable/circle_border.xml
@@ -18,6 +18,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
     <stroke
-        android:width="@dimen/border_width_default"
+        android:width="@dimen/border_height_default"
         android:color="@color/divider"/>
 </shape>

--- a/app/src/main/res/layout/list_item__recent.xml
+++ b/app/src/main/res/layout/list_item__recent.xml
@@ -17,35 +17,38 @@
   ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<LinearLayout
+<android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="horizontal"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/list_item_height_default"
-    android:gravity="center_vertical"
-    android:paddingRight="@dimen/margin_primary"
-    android:paddingLeft="@dimen/margin_primary"
     android:background="@color/windowBackground">
 
     <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/avatar"
         android:layout_width="@dimen/avatar_size_small"
         android:layout_height="@dimen/avatar_size_small"
-        app:civ_border_width="@dimen/border_width_default"
+        android:layout_marginLeft="@dimen/margin_primary"
+        android:layout_marginStart="@dimen/margin_three_quarters"
+        app:layout_constraintBottom_toTopOf="@+id/divider"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:civ_border_color="@color/divider"
+        app:civ_border_width="@dimen/border_height_default"
         tools:src="@mipmap/ic_launcher"/>
 
-    <android.support.v4.widget.Space
-        android:layout_width="@dimen/margin_three_quarters"
-        android:layout_height="match_parent"/>
-
     <LinearLayout
-        android:layout_width="0dp"
+        android:id="@+id/textViews"
+        android:layout_width="@dimen/match_constraints"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        app:layout_constraintBottom_toTopOf="@id/divider"
+        app:layout_constraintLeft_toRightOf="@id/avatar"
+        app:layout_constraintRight_toLeftOf="@id/info"
+        android:layout_marginLeft="@dimen/margin_three_quarters"
+        android:layout_marginStart="@dimen/margin_three_quarters"
+        app:layout_constraintTop_toTopOf="parent">
 
         <TextView
             android:id="@+id/name"
@@ -64,16 +67,22 @@
             android:textSize="14sp"
             tools:text="Damn Daniel! Back at it again with the white vans."
             style="@style/NormalEllipsizeEndStyle"/>
+
     </LinearLayout>
 
-    <android.support.v4.widget.Space
-        android:layout_width="@dimen/margin_three_quarters"
-        android:layout_height="match_parent"/>
-
     <LinearLayout
+        android:id="@+id/info"
         android:layout_width="80dp"
         android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/margin_three_quarters"
+        android:layout_marginStart="@dimen/margin_three_quarters"
+        android:layout_marginRight="@dimen/margin_primary"
+        android:layout_marginEnd="@dimen/margin_primary"
         android:orientation="vertical"
+        app:layout_constraintBottom_toTopOf="@id/divider"
+        app:layout_constraintLeft_toRightOf="@id/textViews"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         android:gravity="right">
 
         <TextView
@@ -98,4 +107,16 @@
             tools:text="99"/>
     </LinearLayout>
 
-</LinearLayout>
+    <View
+        android:id="@+id/divider"
+        style="@style/Border"
+        android:layout_width="@dimen/match_constraints"
+        android:layout_marginLeft="@dimen/border_left_margin_with_small_avatar"
+        android:layout_marginStart="@dimen/border_left_margin_with_small_avatar"
+        android:layout_marginRight="@dimen/margin_primary"
+        android:layout_marginEnd="@dimen/margin_primary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/list_item__recent.xml
+++ b/app/src/main/res/layout/list_item__recent.xml
@@ -23,7 +23,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/list_item_height_default"
-    android:background="@color/windowBackground">
+    android:background="@color/windowBackground"
+    android:foreground="?android:attr/selectableItemBackground"
+    >
 
     <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/avatar"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -76,7 +76,7 @@
     <dimen name="margin_half">8dp</dimen>
     <dimen name="margin_quarter">4dp</dimen>
 
-    <dimen name="border_width_default">1dp</dimen>
+    <dimen name="border_height_default">1dp</dimen>
 
     <dimen name="list_item_height_default">80dp</dimen>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -76,10 +76,16 @@
     <dimen name="margin_half">8dp</dimen>
     <dimen name="margin_quarter">4dp</dimen>
 
+    <!-- Size which will allow a ConstraintLayout to size the element-->
+    <dimen name="match_constraints">0dp</dimen>
+
     <dimen name="border_height_default">1dp</dimen>
 
     <dimen name="list_item_height_default">80dp</dimen>
 
     <dimen name="text_size_default">14sp</dimen>
+
+    <!-- margin_primary + margin_three_quarters + avatar_size_small -->
+    <dimen name="border_left_margin_with_small_avatar">72dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -299,4 +299,9 @@
         <item name="android:layout_width">0dp</item>
     </style>
 
+    <style name="Border">
+        <item name="android:background">@color/border_color</item>
+        <item name="android:layout_height">@dimen/border_height_default</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
I'd actually been thinking about using a `ConstraintLayout` for this before, and it made setting up the divider a LOT easier. 

Also TIL that `android:foreground` exists, which made my life a lot easier. 

![screenshot_20180410-104720](https://user-images.githubusercontent.com/1976498/38564653-df571a62-3cdf-11e8-8190-4bbde0af43d9.png)