### PR TITLE
Pull-to-refresh intercepts child element scroll events in dApp browser

### DIFF
--- a/app/src/main/java/com/toshi/view/activity/webView/LollipopWebViewActivity.kt
+++ b/app/src/main/java/com/toshi/view/activity/webView/LollipopWebViewActivity.kt
@@ -219,6 +219,7 @@ class LollipopWebViewActivity : AppCompatActivity() {
                     onIconReceivedListener = { webViewModel.favicon.value = it }
                 }
         webview.onReloadListener = { load() }
+        swipeToRefresh.setOnChildScrollUpCallback { _, _ -> webview.canScrollUp }
     }
 
     private fun onStartPageLoad() {

--- a/app/src/main/java/com/toshi/view/activity/webView/ToshiWebView.kt
+++ b/app/src/main/java/com/toshi/view/activity/webView/ToshiWebView.kt
@@ -19,21 +19,49 @@ package com.toshi.view.activity.webView
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.support.v4.view.GestureDetectorCompat
 
 class ToshiWebView : WebView {
 
     var toshiWebClient: ToshiWebClient? = null
     var onReloadListener: (() -> Unit)? = null
+    var canScrollUp = false
+        private set
+    private val gestureDetector: GestureDetectorCompat
 
-    constructor(context: Context) : super(context)
-    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle)
+    constructor(context: Context) : super(context) {
+        gestureDetector = GestureDetectorCompat(context, ScrollGestureListener());
+    }
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
+        gestureDetector = GestureDetectorCompat(context, ScrollGestureListener());
+    }
+    constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle) {
+        gestureDetector = GestureDetectorCompat(context, ScrollGestureListener());
+    }
 
     override fun setWebViewClient(client: WebViewClient?) {
         super.setWebViewClient(client)
         toshiWebClient = client as? ToshiWebClient
+    }
+
+    override fun onTouchEvent(event: MotionEvent?): Boolean {
+        return gestureDetector.onTouchEvent(event) || super.onTouchEvent(event)
+    }
+
+    inner class ScrollGestureListener : GestureDetector.SimpleOnGestureListener() {
+        override fun onScroll(start: MotionEvent?, end: MotionEvent?, distanceX: Float, distanceY: Float): Boolean {
+            if (distanceY > 0) canScrollUp = true
+            return false
+        }
+    }
+
+    override fun onOverScrolled(scrollX: Int, scrollY: Int, clampedX: Boolean, clampedY: Boolean) {
+        if (clampedY && scrollY == 0) canScrollUp = false
+        super.onOverScrolled(scrollX, scrollY, clampedX, clampedY)
     }
 
     override fun reload() = onReloadListener?.invoke() ?: super.reload()

--- a/app/src/main/res/layout/activity_web_view.xml
+++ b/app/src/main/res/layout/activity_web_view.xml
@@ -44,25 +44,19 @@
         android:layout_height="0dp"
         android:layout_weight="1">
 
-        <LinearLayout
+        <android.support.v4.widget.SwipeRefreshLayout
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            android:id="@+id/swipeToRefresh"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
+            android:layout_height="match_parent">
 
-            <android.support.v4.widget.SwipeRefreshLayout
-                xmlns:android="http://schemas.android.com/apk/res/android"
-                android:id="@+id/swipeToRefresh"
+            <com.toshi.view.activity.webView.ToshiWebView
+                android:id="@+id/webview"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="0dp"
+                android:layout_weight="1"/>
 
-                <com.toshi.view.activity.webView.ToshiWebView
-                    android:id="@+id/webview"
-                    android:layout_width="match_parent"
-                    android:layout_height="0dp"
-                    android:layout_weight="1"/>
-
-            </android.support.v4.widget.SwipeRefreshLayout>
-        </LinearLayout>
+        </android.support.v4.widget.SwipeRefreshLayout>
 
         <View
             android:id="@+id/supportShadow"


### PR DESCRIPTION
In a few dApps (Etherbots, Ethercraft), I noticed the pull-to-refresh feature interfering with scrollable child elements on the page.

I created a small example page to demonstrate the bug.
http://zeb-test.s3-website-us-west-2.amazonaws.com/child-scroll.htm

![ezgif-5-b1869eb18f](https://user-images.githubusercontent.com/4530237/41477434-edc4344e-7089-11e8-8557-026dc82b01c6.gif)

It appears that this is a known [issue](https://issuetracker.google.com/issues/79404941) and there isn't a clean solution provided by the WebView or SwipeRefreshLayout classes yet.

The solution I'm proposing leverages the onOverScrolled event to ensure that the web page is scrolled to the top before the swipe-to-refresh behavior is able to be triggered. It's not the most elegant solution but until a fix is made to WebView it looks like it's the best way to get these dApps working.